### PR TITLE
Add support for fine grained URL construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,27 @@ Talking to a UNIX socket:
 ;;=> ["borkdude/babashka:0.0.73-SNAPSHOT"]
 ```
 
+Using the low-level API for fine grained(and safer) URL construction:
+
+``` clojure
+(-> (curl/request {:url {:scheme "https"
+                         :host   "httpbin.org"
+                         :port   443
+                         :path   "/get"
+                         :query  "q=test"}})
+    (json/parse-string true))
+;;=>
+{:args {:q "test"},
+ :headers
+ {:Accept "*/*",
+  :Host "httpbin.org",
+  :User-Agent "curl/7.64.1",
+  :X-Amzn-Trace-Id
+  "Root=1-5e63989e-7bd5b1dba75e951a84d61b6a"},
+ :origin "46.114.35.45",
+ :url "https://httpbin.org/get?q=test"}
+```
+
 ## Test
 
 ``` clojure

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -4,7 +4,8 @@
             [clojure.string :as str]
             [clojure.java.io :as io])
   (:import [java.lang ProcessBuilder$Redirect]
-           [java.net URLEncoder]))
+           [java.net URLEncoder]
+           [java.net URI]))
 
 ;;;; Utils
 
@@ -97,7 +98,19 @@
         data-raw (:data-raw opts)
         data-raw (when data-raw
                    ["--data-raw" data-raw])
-        url (:url opts)
+        url (let [url* (:url opts)]
+              (cond
+                (string? url*)
+                url*
+
+                (map? url*)
+                (str (URI. ^String (:scheme url*)
+                           ^String (:user url*)
+                           ^String (:host url*)
+                           ^Integer (:port url*)
+                           ^String (:path url*)
+                           ^String (:query url*)
+                           ^String (:fragment url*)))))
         in-file (:in-file opts)
         in-file (when in-file ["-d" (str "@" (.getCanonicalPath ^java.io.File in-file))])
         basic-auth (:basic-auth opts)
@@ -154,3 +167,12 @@
    (let [opts (assoc opts :url url
                      :method :patch)]
      (request opts))))
+
+(comment
+  ;; after running a python server in the source repo with `python3 -m http.server`
+  (request {:url      {:host   "localhost"
+                       :scheme "http"
+                       :port   8000
+                       :path   "/src/babashka"}
+            :raw-args ["-L"]})
+  )

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -7,6 +7,8 @@
            [java.net URLEncoder]
            [java.net URI]))
 
+(set! *warn-on-reflection* true)
+
 ;;;; Utils
 
 (defn- shell-command

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -71,6 +71,16 @@
              (json/parse-string)
              (get "args")))))
 
+(deftest low-level-url-test
+  (let [response (-> (curl/request {:url {:scheme "https"
+                                          :host   "httpbin.org"
+                                          :port   443
+                                          :path   "/get"
+                                          :query  "q=test"}})
+                     (json/parse-string true))]
+    (is (= {:q "test"} (:args response)))
+    (is (= "httpbin.org" (get-in response [:headers :Host])))))
+
 ;; untested, but works:
 ;; $ export BABASHKA_CLASSPATH=src
 ;; $ cat README.md | bb "(require '[babashka.curl :as curl]) (curl/post \"https://postman-echo.com/post\" {:raw-args [\"-d\" \"@-\"]})"


### PR DESCRIPTION
- Use java.net.URI to construct URLs via maps
- Support scheme, username, host, port, path, query and fragment options