### PR TITLE
Allow returning response as a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ Simple `GET` request:
 ;;=> "200 OK"
 ```
 
+Simple `GET` request returned as a map:
+
+```
+(curl/get "https://httpstat.us/200" {:response true})
+;;=> {:status 200 :body "200 OK" :headers { .. }}
+```
+
 Passing headers:
 
 ``` clojure

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -3,7 +3,7 @@
             [cheshire.core :as json]
             [clojure.java.io :as io]
             [clojure.string :as str]
-            [clojure.test :refer [deftest is testing]]))
+            [clojure.test :refer [deftest is testing are]]))
 
 (deftest get-test
   (is (str/includes? (curl/get "https://httpstat.us/200")
@@ -58,6 +58,39 @@
                    :raw-args ["-D" "-"]})
        "200 OK")))
 
+(deftest get-response-object-test
+  (let [response (curl/get "https://httpstat.us/200" {:response true})]
+    (is (map? response))
+    (is (= 200 (:status response)))
+    (is (= "200 OK" (:body response)))
+    (is (= "Microsoft-IIS/10.0" (get-in response [:headers "server"]))))
+
+  (testing "response object as stream"
+    (let [response (curl/get "https://httpstat.us/200" {:response true :as :stream})]
+      (is (map? response))
+      (is (= 200 (:status response)))
+      (is (instance? java.io.InputStream (:body response)))
+      (is (= "200 OK" (slurp (:body response))))))
+
+  (testing "response object with following redirect"
+    (let [response (curl/get "https://httpbin.org/redirect-to?url=https://www.httpbin.org"
+                             {:raw-args ["-L"]
+                              :response true})]
+      (is (map? response))
+      (is (= 200 (:status response)))
+      (is (= 302 (-> response :redirects first :status)))
+      (is (= "https://www.httpbin.org" (get-in response [:redirects 0 :headers "location"])))))
+
+  (testing "response object without fully following redirects"
+    (let [response (curl/get "https://httpbin.org/redirect-to?url=https://www.httpbin.org"
+                             {:response true
+                              :raw-args ["--max-redirs" "0"]})]
+      (is (map? response))
+      (is (= 302 (:status response)))
+      (is (= "" (:body response)))
+      (is (= "https://www.httpbin.org" (get-in response [:headers "location"])))
+      (is (empty? (:redirects response))))))
+
 (deftest accept-header-test
   (is (= 200
          (-> (curl/get "https://httpstat.us/200"
@@ -88,6 +121,81 @@
              tmp-file)
     (is (= (.length (io/file "test" "icon.png"))
            (.length tmp-file)))))
+
+(deftest curl-response->map-test
+  (are [expected input] (= expected (curl/curl-response->map (clojure.java.io/input-stream (.getBytes (str/join "\n" input))) {}))
+    ;;; Basic Response Parsing
+    ;; expected
+    {:status  200
+     :headers {"server"         "SimpleHTTP/0.6 Python/3.7.3"
+               "date"           "Wed, 01 Apr 2020 04:38:35 GMT"
+               "content-type"   "application/octet-stream"
+               "content-length" "39"
+               "last-modified"  "Wed, 01 Apr 2020 04:23:07 GMT"}
+     :body    "hello\nworld\n\nfoo"}
+
+    ;; input
+    ["HTTP/1.0 200 OK"
+     "Server: SimpleHTTP/0.6 Python/3.7.3"
+     "Date: Wed, 01 Apr 2020 04:38:35 GMT"
+     "Content-type: application/octet-stream"
+     "Content-Length: 39"
+     "Last-Modified: Wed, 01 Apr 2020 04:23:07 GMT"
+     ""
+     "hello"
+     "world"
+     ""
+     "foo"]
+
+    ;;; Following a redirect
+    ;; expected
+    {:status    200,
+     :headers   {"date"          "Wed, 01 Apr 2020 05:16:48 GMT"
+                 "cache-control" "private, max-age=0"
+                 "content-type"  "text/html; charset=ISO-8859-1"
+                 "vary"          "Accept-Encoding"}
+     :body      "<!doctype html>"
+     :redirects [{:status  302
+                  :headers {"date"           "Wed, 01 Apr 2020 05:16:48 GMT"
+                            "content-type"   "text/html; charset=utf-8"
+                            "content-length" "0"
+                            "location"       "https://www.google.com"
+                            "server"         "gunicorn/19.9.0"}}]}
+
+    ;; input
+    ["HTTP/2 302"
+     "date: Wed, 01 Apr 2020 05:16:48 GMT"
+     "content-type: text/html; charset=utf-8"
+     "content-length: 0"
+     "location: https://www.google.com"
+     "server: gunicorn/19.9.0"
+     ""
+     "HTTP/2 200"
+     "date: Wed, 01 Apr 2020 05:16:48 GMT"
+     "cache-control: private, max-age=0"
+     "content-type: text/html; charset=ISO-8859-1"
+     "vary: Accept-Encoding"
+     ""
+     "<!doctype html>"]
+
+    ;;; Redirect without following, i.e.
+    ;; $ curl --include -L 'https://httpbin.org/redirect-to?url=https://www.google.com' --max-redirs 0
+    ;; expected
+    {:status  302
+     :headers {"date"           "Wed, 01 Apr 2020 05:23:34 GMT"
+               "content-type"   "text/html; charset=utf-8"
+               "content-length" "0"
+               "location"       "https://www.google.com"
+               "server"         "gunicorn/19.9.0"}
+     :body    ""}
+
+    ;; input
+    ["HTTP/2 302"
+     "date: Wed, 01 Apr 2020 05:23:34 GMT"
+     "content-type: text/html; charset=utf-8"
+     "content-length: 0"
+     "location: https://www.google.com"
+     "server: gunicorn/19.9.0"]))
 
 ;; untested, but works:
 ;; $ export BABASHKA_CLASSPATH=src


### PR DESCRIPTION
Fixes #5 

Implements support for returning the curl response as a map, similar to clj-http and ring. 

The implementation uses a deprecated method [DataInputReader#readLine](https://docs.oracle.com/javase/8/docs/api/java/io/DataInputStream.html#readLine--). From testing, it does not appear to properly parse unicode characters:

``` clojure
;; using deprecated method
user> (.readLine (java.io.DataInputStream. (clojure.java.io/input-stream (.getBytes "🙇‍♀️👏"))))
"ðââï¸ð"

;; using recommendation of a reader
user> (.readLine (clojure.java.io/reader (clojure.java.io/input-stream (.getBytes "🙇‍♀️👏"))))
"🙇‍♀️👏"
```

Fortunately, HTTP Messages, specifically Status Line & Headers are encoded in the ASCII range which minimizes the risk of improper conversion. See [link](https://developer.mozilla.org/en-US/docs/Web/HTTP/Messages ).

This PR makes the conscious trade-off of using the deprecated method to avoid rewriting this snippet of Java code. See [source](https://hg.openjdk.java.net/jdk8/jdk8/jdk/file/687fd7c7986d/src/share/classes/java/io/DataInputStream.java#l501).

---

### Test Cases

- basic request/response (covered in tests)
- request/response following redirect (covered in tests)
- streaming the body to a file (see below)

``` Clojure
(require '[clojure.java.io :as io])
(io/copy
  (:body
    (curl/get "https://github.com/borkdude/babashka/raw/master/logo/icon.png"
      {:response true :as :stream}))
  (io/file "icon.png"))
```
