### PR TITLE
Capture standard error from curl shell command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ flycheck_*.el
 
 **/.clj-kondo/.cache
 
+.idea/

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Using the low-level API for fine grained(and safer) URL construction:
  :url "https://httpbin.org/get?q=test"}
 ```
 
+### Error output
+
+Error output can be found under the `:err` key:
+
+``` clojure
+(:err (curl/get "httpx://postman-echo.com/get"))
+;;=> "curl: (1) Protocol \"httpx\" not supported or disabled in libcurl\n"
+```
+
 ### Debugging requests
 
 Set `:debug` to `true` to get debugging information along with the response. The

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -172,9 +172,9 @@
                   :headers headers
                   :body body
                   :process (:proc opts)}
-        err-is ^java.io.InputStream (slurp (:err opts))
-        response (if (not (str/blank? err-is))
-                   (assoc response :curl/stderr err-is)
+        err ^java.io.InputStream (slurp (:err opts))
+        response (if (not (str/blank? err))
+                   (assoc response :curl/stderr err)
                    response)]
     response))
 

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -174,7 +174,7 @@
                   :process (:proc opts)}
         err ^java.io.InputStream (slurp (:err opts))
         response (if (not (str/blank? err))
-                   (assoc response :curl/stderr err)
+                   (assoc response :error err)
                    response)]
     response))
 

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -179,5 +179,5 @@
 
 (deftest stderr-test
   (let [resp (curl/get "blah://postman-echo.com/get")]
-    (is (contains? resp :curl/stderr))
-    (is (str/starts-with? (:curl/stderr resp) "curl: (1)"))))
+    (is (contains? resp :error))
+    (is (str/starts-with? (:error resp) "curl: (1)"))))

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -5,6 +5,10 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
+(defmethod clojure.test/report :begin-test-var [m]
+  (println "===" (-> m :var meta :name))
+  (println))
+
 (deftest get-test
   (is (str/includes? (:body (curl/get "https://httpstat.us/200"))
                      "200"))
@@ -179,5 +183,5 @@
 
 (deftest stderr-test
   (let [resp (curl/get "blah://postman-echo.com/get")]
-    (is (contains? resp :error))
-    (is (str/starts-with? (:error resp) "curl: (1)"))))
+    (is (contains? resp :err))
+    (is (str/starts-with? (:err resp) "curl: (1)"))))

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -176,3 +176,8 @@
         opts (:options resp)]
     (is (pos? (.indexOf command "--head")))
     (is (identical? :head (:method opts)))))
+
+(deftest stderr-test
+  (let [resp (curl/get "blah://postman-echo.com/get")]
+    (is (contains? resp :curl/stderr))
+    (is (str/starts-with? (:curl/stderr resp) "curl: (1)"))))


### PR DESCRIPTION
If there is a nonzero exit status code from the `curl` shell command, there is an error message written to standard error. This pull request captures the error message, if one exists, and adds a key for it in the resulting response object.