### PR TITLE
BREAKING: Throw exceptions on errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ flycheck_*.el
 
 **/.clj-kondo/.cache
 
+.idea/

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,4 @@
 # Changes
 
 - [#9](https://github.com/borkdude/babashka.curl/issues/9): BREAKING! Functions like `get`, `post`, etc. now always return a map with `:status`, `:body`, and `:headers`.
+- [#16](https://github.com/borkdude/babashka.curl/issues/16): BREAKING! Exceptional status codes or nonzero `curl` exit codes will throw exceptions by default.

--- a/README.md
+++ b/README.md
@@ -163,6 +163,15 @@ Using the low-level API for fine grained(and safer) URL construction:
  :url "https://httpbin.org/get?q=test"}
 ```
 
+### Error output
+
+Error output can be found under the `:err` key:
+
+``` clojure
+(:err (curl/get "httpx://postman-echo.com/get"))
+;;=> "curl: (1) Protocol \"httpx\" not supported or disabled in libcurl\n"
+```
+
 ### Debugging requests
 
 Set `:debug` to `true` to get debugging information along with the response. The

--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ or if `curl` exited with a non-zero exit code. The response map is the exception
 ```clojure
 (curl/get "https://httpstat.us/404")
 ;;=> Execution error (ExceptionInfo) at babashka.curl/request (curl.clj:228).
-;;=> status 404
+     status 404
 
 (:status (ex-data *e))
 ;;=> 404

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -187,13 +187,13 @@
 (defn- should-throw? [response opts]
   (let [exceptional-status? (not (unexceptional-status? (:status response)))
         nonzero-exit? (not (zero? (:exit response)))]
-    (and (:throw-exceptions opts)
+    (and (:throw opts)
          (or exceptional-status? nonzero-exit?))))
 
 (defn request [opts]
   (let [header-file (File/createTempFile "babashka.curl" ".headers")
         opts (assoc opts :header-file header-file)
-        default-opts {:throw-exceptions true}
+        default-opts {:throw true}
         opts (merge default-opts opts)
         args (curl-command opts)
         response (let [response (-> (exec-curl args opts)

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -156,9 +156,10 @@
         is (read-then-unread is)
         err (:err opts)
         stream? (identical? :stream (:as opts))
-        [body err] (if stream?
-                     [is err]
-                     [(slurp is) (slurp err)])
+        process (:proc opts)
+        [body err exit] (if stream?
+                          [is err (delay (.waitFor ^java.lang.Process process))]
+                          [(slurp is) (slurp err) (.waitFor ^java.lang.Process process)])
         headers (read-headers (:header-file opts))
         [status headers]
         (reduce (fn [[status parsed-headers :as acc] header-line]
@@ -174,23 +175,39 @@
                   :headers headers
                   :body body
                   :err err
-                  :process (:proc opts)}]
+                  :process process
+                  :exit exit}]
     response))
 
 ;;;; End Response Parsing
 
+(def unexceptional-status?
+  #{200 201 202 203 204 205 206 207 300 301 302 303 304 307})
+
+(defn- should-throw? [response opts]
+  (let [exceptional-status? (not (unexceptional-status? (:status response)))
+        nonzero-exit? (not (zero? (:exit response)))]
+    (and (:throw-exceptions opts)
+         (or exceptional-status? nonzero-exit?))))
+
 (defn request [opts]
   (let [header-file (File/createTempFile "babashka.curl" ".headers")
         opts (assoc opts :header-file header-file)
+        default-opts {:throw-exceptions true}
+        opts (merge default-opts opts)
         args (curl-command opts)
         response (let [response (-> (exec-curl args opts)
                                     (curl-response->map))]
                    (.delete header-file)
-                   response)]
-    (if (:debug opts)
-      (assoc response
-             :command args
-             :options opts)
+                   response)
+        response (if (:debug opts)
+                   (assoc response
+                     :command args
+                     :options opts)
+                   response)
+        stream? (identical? :stream (:as opts))]
+    (if (and (not stream?) (should-throw? response opts))
+      (throw (ex-info "error" response))
       response)))
 
 (defn head

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -197,6 +197,17 @@
     (and (:throw opts)
          (or exceptional-status? nonzero-exit?))))
 
+(defn- build-ex-msg [response]
+  (cond
+    (:status response)
+    (str "status " (:status response))
+
+    (not (str/blank? (:err response)))
+    (:err response)
+
+    :else
+    "error"))
+
 (defn request [opts]
   (let [header-file (File/createTempFile "babashka.curl" ".headers")
         opts (assoc opts :header-file header-file)
@@ -214,7 +225,7 @@
                    response)
         stream? (identical? :stream (:as opts))]
     (if (and (not stream?) (should-throw? response opts))
-      (throw (ex-info "error" response))
+      (throw (ex-info (build-ex-msg response) response))
       response)))
 
 (defn head

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -172,9 +172,9 @@
                   :headers headers
                   :body body
                   :process (:proc opts)}
-        err-is ^java.io.InputStream (slurp (:err opts))
-        response (if (not (str/blank? err-is))
-                   (assoc response :curl/stderr err-is)
+        err ^java.io.InputStream (slurp (:err opts))
+        response (if (not (str/blank? err))
+                   (assoc response :curl/stderr err)
                    response)]
     response))
 

--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -174,7 +174,7 @@
                   :process (:proc opts)}
         err ^java.io.InputStream (slurp (:err opts))
         response (if (not (str/blank? err))
-                   (assoc response :curl/stderr err)
+                   (assoc response :error err)
                    response)]
     response))
 

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -179,5 +179,5 @@
 
 (deftest stderr-test
   (let [resp (curl/get "blah://postman-echo.com/get")]
-    (is (contains? resp :curl/stderr))
-    (is (str/starts-with? (:curl/stderr resp) "curl: (1)"))))
+    (is (contains? resp :error))
+    (is (str/starts-with? (:error resp) "curl: (1)"))))

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -89,7 +89,7 @@
   (testing "response object without fully following redirects"
     (let [response (curl/get "https://httpbin.org/redirect-to?url=https://www.httpbin.org"
                              {:raw-args ["--max-redirs" "0"]
-                              :throw-exceptions false})]
+                              :throw false})]
       (is (map? response))
       (is (= 302 (:status response)))
       (is (= "" (:body response)))
@@ -183,6 +183,6 @@
     (is (identical? :head (:method opts)))))
 
 (deftest stderr-test
-  (let [resp (curl/get "blah://postman-echo.com/get" {:throw-exceptions false})]
+  (let [resp (curl/get "blah://postman-echo.com/get" {:throw false})]
     (is (contains? resp :err))
     (is (str/starts-with? (:err resp) "curl: (1)"))))

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -5,6 +5,10 @@
             [clojure.string :as str]
             [clojure.test :refer [deftest is testing]]))
 
+(defmethod clojure.test/report :begin-test-var [m]
+  (println "===" (-> m :var meta :name))
+  (println))
+
 (deftest get-test
   (is (str/includes? (:body (curl/get "https://httpstat.us/200"))
                      "200"))
@@ -179,5 +183,5 @@
 
 (deftest stderr-test
   (let [resp (curl/get "blah://postman-echo.com/get")]
-    (is (contains? resp :error))
-    (is (str/starts-with? (:error resp) "curl: (1)"))))
+    (is (contains? resp :err))
+    (is (str/starts-with? (:err resp) "curl: (1)"))))

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -176,3 +176,8 @@
         opts (:options resp)]
     (is (pos? (.indexOf command "--head")))
     (is (identical? :head (:method opts)))))
+
+(deftest stderr-test
+  (let [resp (curl/get "blah://postman-echo.com/get")]
+    (is (contains? resp :curl/stderr))
+    (is (str/starts-with? (:curl/stderr resp) "curl: (1)"))))

--- a/test/babashka/curl_test.clj
+++ b/test/babashka/curl_test.clj
@@ -88,7 +88,8 @@
 
   (testing "response object without fully following redirects"
     (let [response (curl/get "https://httpbin.org/redirect-to?url=https://www.httpbin.org"
-                             {:raw-args ["--max-redirs" "0"]})]
+                             {:raw-args ["--max-redirs" "0"]
+                              :throw-exceptions false})]
       (is (map? response))
       (is (= 302 (:status response)))
       (is (= "" (:body response)))
@@ -182,6 +183,6 @@
     (is (identical? :head (:method opts)))))
 
 (deftest stderr-test
-  (let [resp (curl/get "blah://postman-echo.com/get")]
+  (let [resp (curl/get "blah://postman-echo.com/get" {:throw-exceptions false})]
     (is (contains? resp :err))
     (is (str/starts-with? (:err resp) "curl: (1)"))))


### PR DESCRIPTION
This pull request attempts to make `babashka.curl` behave similarly to `clj-http` around exceptions. It does the following as outlined in this [issue](https://github.com/borkdude/babashka.curl/issues/16#issuecomment-617660057) from @borkdude.

> * I think the error codes from the process can be captured as an :exit key.
> * If that exit is non-zero then throw an ex-info with the entire response-map attached as data
> * Also conforming to clj-http's behavior: throw when http status codes would be nice with the option to opt out of it.
> * In the case of streaming (:as :stream), the exit code should maybe be a delay with the exit code contained in it? And throwing errors is automatically opted out of?