### PR TITLE
fix typo

### DIFF
--- a/src/babashka/curl.clj
+++ b/src/babashka/curl.clj
@@ -14,7 +14,7 @@
   "Executes shell command.
   Accepts the following options:
   `:input`: instead of reading from stdin, read from this string.
-  `:to-string?`: instead of writing to stdoud, write to a string and
+  `:to-string?`: instead of writing to stdout, write to a string and
   return it.
   `:throw?`: Unless `false`, exits script when the shell-command has a
   non-zero exit code, unless `throw?` is set to false."


### PR DESCRIPTION
fix a small typo in shell-command function docstring